### PR TITLE
feat(cli): add --open flag to jiuwensymbiosis-replay to launch HTML in browser

### DIFF
--- a/docs/en/how-to/use-tracing.md
+++ b/docs/en/how-to/use-tracing.md
@@ -101,6 +101,7 @@ jiuwensymbiosis-replay path/to/trace.json
 
 The command writes `<run-token>.html` beside the JSON when possible and prints its path. Images are embedded as base64,
 so the HTML can be moved or shared without the original frame directory.
+Add `--open` to launch the generated HTML in your default browser automatically.
 
 For a terminal timeline:
 

--- a/docs/en/reference/cli.md
+++ b/docs/en/reference/cli.md
@@ -18,10 +18,11 @@ Common temporary overrides include `--model`, `--server-url`, `--api-key`, `--ma
 ## `jiuwensymbiosis-replay`
 
 ```bash
-jiuwensymbiosis-replay TRACE_JSON [--text]
+jiuwensymbiosis-replay TRACE_JSON [--open] [--text]
 ```
 
-The default mode generates a self-contained HTML replay and prints its path. `--text` prints a terminal timeline and
+The default mode generates a self-contained HTML replay and prints its path. `--open` additionally launches the HTML in
+the default browser. `--text` prints a terminal timeline and
 frame paths without generating the visual report.
 
 ## `jiuwensymbiosis-gui`

--- a/docs/zh/how-to/use-tracing.md
+++ b/docs/zh/how-to/use-tracing.md
@@ -92,6 +92,7 @@ agent = build_robot_agent(session, config)
 
 ```bash
 jiuwensymbiosis-replay <trace.json>                  # 默认：生成 HTML + 打印可点击路径（不自动开浏览器）
+jiuwensymbiosis-replay <trace.json> --open           # 生成 HTML 后自动用默认浏览器打开
 jiuwensymbiosis-replay <trace.json> --text           # 回退纯文本时间线（帧仅显示路径）
 ```
 

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -13,10 +13,10 @@ piper-pick-demo --config PATH [--query TEXT | --voice ...] [--mock]
 ## jiuwensymbiosis-replay
 
 ```bash
-jiuwensymbiosis-replay TRACE_JSON [--text]
+jiuwensymbiosis-replay TRACE_JSON [--open] [--text]
 ```
 
-默认生成自包含 HTML 回放并打印路径；`--text` 输出终端时间线。
+默认生成自包含 HTML 回放并打印路径；`--open` 生成后自动用默认浏览器打开；`--text` 输出终端时间线。
 
 ## jiuwensymbiosis-gui
 

--- a/jiuwensymbiosis/cli.py
+++ b/jiuwensymbiosis/cli.py
@@ -10,6 +10,7 @@ import json
 import logging
 import runpy
 import sys
+import webbrowser
 from pathlib import Path
 from typing import Any
 
@@ -148,7 +149,7 @@ def replay(trace_path: str, *, out=sys.stdout) -> int:
     return 0
 
 
-def replay_html(trace_path: str, *, out=sys.stdout) -> int:
+def replay_html(trace_path: str, *, out=sys.stdout, open_browser: bool = False) -> int:
     """Render a trace as a self-contained HTML page and print its path.
 
     The HTML is written next to the trace JSON as ``{json_stem}.html`` with
@@ -159,6 +160,7 @@ def replay_html(trace_path: str, *, out=sys.stdout) -> int:
     Args:
         trace_path: Path to a ``traces/*.json`` written by ``TraceRail``.
         out: Output stream for the "wrote …" status line.
+        open_browser: When True, open the written HTML in the default browser.
 
     Returns:
         Process exit code (0 on success, 1 if the trace is missing/invalid).
@@ -185,10 +187,14 @@ def replay_html(trace_path: str, *, out=sys.stdout) -> int:
             return 1
 
     print(f"wrote {out_path}", file=out)
-    print(
-        "(open the path above in your browser)",
-        file=out,
-    )
+    if open_browser:
+        if not webbrowser.open(out_path.resolve().as_uri()):
+            logger.warning("could not open a browser; open the path above manually")
+    else:
+        print(
+            "(open the path above in your browser, or re-run with --open)",
+            file=out,
+        )
     return 0
 
 
@@ -210,7 +216,12 @@ def replay_main() -> int:
         action="store_true",
         help="Print a text timeline instead of generating HTML.",
     )
+    parser.add_argument(
+        "--open",
+        action="store_true",
+        help="After generating the HTML, open it in the default browser.",
+    )
     args = parser.parse_args()
     if args.text:
         return replay(args.trace_path)
-    return replay_html(args.trace_path)
+    return replay_html(args.trace_path, open_browser=args.open)

--- a/tests/unit_tests/test_cli_replay.py
+++ b/tests/unit_tests/test_cli_replay.py
@@ -129,3 +129,40 @@ class TestReplayHtml:
         p.write_text("{not json", encoding="utf-8")
         rc = replay_html(str(p))
         assert rc == 1
+
+    def test_open_browser_calls_webbrowser(self, tmp_path, monkeypatch):
+        import webbrowser
+
+        p = tmp_path / "conv-1.json"
+        p.write_text(json.dumps(_sample_trace()), encoding="utf-8")
+        opened = []
+        monkeypatch.setattr(webbrowser, "open", lambda url: opened.append(url) or True)
+        rc = replay_html(str(p), out=io.StringIO(), open_browser=True)
+        assert rc == 0
+        assert opened == [p.with_suffix(".html").resolve().as_uri()]
+
+    def test_default_does_not_open_browser(self, tmp_path, monkeypatch):
+        import webbrowser
+
+        p = tmp_path / "conv-1.json"
+        p.write_text(json.dumps(_sample_trace()), encoding="utf-8")
+
+        def _fail(url):
+            raise AssertionError("should not open a browser by default")
+
+        monkeypatch.setattr(webbrowser, "open", _fail)
+        rc = replay_html(str(p), out=io.StringIO())
+        assert rc == 0
+
+    def test_main_open_flag(self, tmp_path, monkeypatch):
+        import webbrowser
+
+        from jiuwensymbiosis.cli import replay_main
+
+        p = tmp_path / "conv-1.json"
+        p.write_text(json.dumps(_sample_trace()), encoding="utf-8")
+        opened = []
+        monkeypatch.setattr(webbrowser, "open", lambda url: opened.append(url) or True)
+        monkeypatch.setattr("sys.argv", ["jiuwensymbiosis-replay", str(p), "--open"])
+        assert replay_main() == 0
+        assert opened == [p.with_suffix(".html").resolve().as_uri()]


### PR DESCRIPTION
## What

Add an `--open` flag to `jiuwensymbiosis-replay`: after generating the self-contained HTML replay, automatically open it in the default browser via stdlib `webbrowser` (pure stdlib, no hardware needed).

```bash
jiuwensymbiosis-replay <trace.json> --open
```

- Default behavior unchanged (HTML + printed path); hint line now mentions `--open`.
- If no browser can be launched, logs a warning and still exits 0 (the HTML was written successfully).
- `--text` path is unaffected.

## Changes

- `jiuwensymbiosis/cli.py`: `replay_html(..., open_browser=False)` + `--open` argparse flag; top-level `import webbrowser`.
- `tests/unit_tests/test_cli_replay.py`: 3 new tests — `--open` calls `webbrowser.open` with the exact file URI; default does not open a browser; end-to-end `replay_main --open`.
- Docs: `docs/{zh,en}/how-to/use-tracing.md` and `docs/{zh,en}/reference/cli.md` updated for the new flag.

## Verification

- `pytest tests/unit_tests/test_cli_replay.py` → 11 passed
- `ruff format --check` / `ruff check` → clean